### PR TITLE
Cambiato endpoint criteria filtraCategorie da GetMapping a PostMapping.  Inserito filter su filtraCategorie per ottenere solo categorie non cancellate.

### DIFF
--- a/src/main/java/com/example/venditabiglietti_categoria/controller/CategoriaController.java
+++ b/src/main/java/com/example/venditabiglietti_categoria/controller/CategoriaController.java
@@ -127,7 +127,7 @@ public class CategoriaController {
         return ResponseEntity.status(HttpStatus.OK).body(categoriaService.findAllByNomeList(nomiCategorie));
     }
 
-    @GetMapping("/filtraCategorie")
+    @PostMapping("/filtraCategorie")
     public ResponseEntity<List<Categoria>> filtraCategorie(@RequestBody FiltroCategoriaDTORequest request){
         return ResponseEntity.ok().body(categoriaService.filtraCategorie(request));
     }

--- a/src/main/java/com/example/venditabiglietti_categoria/service/impl/CategoriaServiceImpl.java
+++ b/src/main/java/com/example/venditabiglietti_categoria/service/impl/CategoriaServiceImpl.java
@@ -82,6 +82,6 @@ public class CategoriaServiceImpl implements CategoriaServiceDef {
 
     @Override
     public List<Categoria> filtraCategorie(FiltroCategoriaDTORequest request) {
-        return criteriaCategoriaRepository.filtraCategorie(request);
+        return criteriaCategoriaRepository.filtraCategorie(request).stream().filter(c -> !c.isCancellato()).toList();
     }
 }


### PR DESCRIPTION
Cambiato endpoint criteria filtraCategorie da GetMapping a PostMapping (altrimenti da errore sulla criteria di eventiFiltrati del principale). Inserito filter su filtraCategorie per ottenere solo luoghi non cancellati.